### PR TITLE
Fix "argument of type 'NoneType' is not iterable"

### DIFF
--- a/annotate_json.py
+++ b/annotate_json.py
@@ -248,7 +248,7 @@ def n2a(n,b=string.ascii_uppercase):
    return n2a(d-1,b)+b[m] if d else b[m]
 
 def pipeline(ijd, ojson, floor=0, size=0, distinction=0, cutoff=1, missense=False, gene=None, maxlevels=0, labels=None, reportf=None):
-    if ',' in gene:
+    if gene is not None and ',' in gene:
         gene = gene.split(",")
     t = Tree().load_from_dict(ijd['tree'], 1, missense, gene)
     if t.parsimony_score() == 0:


### PR DESCRIPTION
This PR does the following:

Python shows the “TypeError: argument of type ‘NoneType’ is not iterable” error when a membership operator (in, not in) is used on a None object. Hence to fix that, an additional if condition is added to check if the object is a `None` object.

## Error

```
File "automated-lineage-json/annotate_json.py", line 349, in <module>
    main()
  File "automated-lineage-json/annotate_json.py", line 346, in main
    pipeline(ijd,args.output,args.floor,args.size,args.distinction,args.cutoff,args.missense,args.gene,args.levels,args.labels,args.report)
  File "automated-lineage-json/annotate_json.py", line 251, in pipeline
    if ',' in gene:
TypeError: argument of type 'NoneType' is not iterable
```

## How to reproduce the error

1. Run `python3 annotate_json.py` without the `-g` or `--gene` flag